### PR TITLE
Add global utilities and cleanup

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,6 @@
 export default function About() {
   return (
-    <main className="bg-black text-white min-h-screen p-8">
+    <main className="section-dark min-h-screen p-8">
       <h1 className="text-4xl font-bold mb-4">About Us</h1>
       <p className="text-gray-400 max-w-2xl">
         Discrete Society is an underground streetwear brand focused on clean design,

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,19 +1,40 @@
-@import "tailwindcss";
-
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: sans-serif;
+  @apply bg-black text-white;
+}
+
+.section-light {
+  @apply bg-white text-black;
+}
+
+.section-dark {
+  @apply bg-black text-white;
+}
+
+@layer utilities {
+  .spin-slow {
+    animation: spin 6s linear infinite;
+  }
+  @keyframes spin {
+    from {
+      transform: rotateY(0deg);
+    }
+    to {
+      transform: rotateY(360deg);
+    }
+  }
+  .animate-marquee {
+    animation: marquee 20s linear infinite;
+  }
+  @keyframes marquee {
+    0% {
+      transform: translateX(0%);
+    }
+    100% {
+      transform: translateX(-50%);
+    }
+  }
 }

--- a/app/lookbook/page.tsx
+++ b/app/lookbook/page.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+import fs from "fs";
+import path from "path";
+
+export default async function Lookbook() {
+  const dir = path.join(process.cwd(), "public", "lookbook");
+  let images: string[] = [];
+  try {
+    images = await fs.promises.readdir(dir);
+  } catch {
+    images = [];
+  }
+
+  return (
+    <main className="section-light min-h-screen px-4 py-12">
+      <h1 className="text-4xl font-bold text-center mb-2">LOOKBOOK</h1>
+      <p className="text-center text-gray-600 mb-8">Explore our latest pieces.</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-6xl mx-auto">
+        {images.map((src) => (
+          <div key={src} className="overflow-hidden rounded-lg">
+            <Image
+              src={`/lookbook/${src}`}
+              alt="Lookbook image"
+              width={800}
+              height={800}
+              className="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
+            />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,24 +50,7 @@ export default function Home() {
   }, []);
 
   return (
-    <main className="bg-black text-white min-h-screen font-sans flex flex-col overflow-x-hidden">
-      <style>{`
-        .spin-slow {
-          animation: spin 6s linear infinite;
-        }
-        @keyframes spin {
-          from { transform: rotateY(0deg); }
-          to { transform: rotateY(360deg); }
-        }
-
-        @keyframes marquee {
-          0% { transform: translateX(0%); }
-          100% { transform: translateX(-50%); }
-        }
-        .animate-marquee {
-          animation: marquee 20s linear infinite;
-        }
-      `}</style>
+    <main className="section-dark min-h-screen font-sans flex flex-col overflow-x-hidden">
 
       {/* Hero */}
       <section className="flex flex-col items-center justify-center h-screen text-center px-4">

--- a/app/policy/page.tsx
+++ b/app/policy/page.tsx
@@ -1,6 +1,6 @@
 export default function Policy() {
   return (
-    <main className="bg-black text-white min-h-screen px-8 py-12 font-sans">
+    <main className="section-dark min-h-screen px-8 py-12 font-sans">
       <h1 className="text-3xl font-bold mb-8">Store Policies</h1>
 
       <section className="mb-6">

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -4,7 +4,7 @@ import ProductGrid from "./ProductGrid";
 export default async function Shop() {
   const products = await fetchShopifyProducts();
   return (
-    <main className="bg-black text-white min-h-screen px-8 py-12">
+    <main className="section-dark min-h-screen px-8 py-12">
       <h1 className="text-4xl font-bold mb-8 text-center">Shop</h1>
       <ProductGrid products={products} />
     </main>

--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -19,7 +19,7 @@ export default function CartDrawer() {
     />
 
     {/* drawer */}
-    <div className="fixed top-0 right-0 w-96 h-full bg-black text-white z-50 shadow-2xl flex flex-col p-6">
+    <div className="section-dark fixed top-0 right-0 w-96 h-full z-50 shadow-2xl flex flex-col p-6">
       <button className="self-end mb-4" onClick={toggleCartOpen}>Close</button>
       <h2 className="text-2xl mb-4">Your Cart</h2>
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,7 +8,7 @@ export default function Navbar() {
   const { cart, toggleCartOpen } = useCart();
 
   return (
-    <nav className="bg-black text-white px-8 py-4 flex justify-between items-center border-b border-gray-800">
+    <nav className="section-dark px-8 py-4 flex justify-between items-center border-b border-gray-800">
       <Link href="/" className="flex items-center gap-2">
         <Image
           src="/logo.png"


### PR DESCRIPTION
## Summary
- move site-wide colors and animations into `globals.css`
- apply `.section-dark` and `.section-light` utilities across pages
- keep hero animations with new global classes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688812b57e348331894daccae044ceea